### PR TITLE
Add minitest development dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+Gemfile.lock

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,4 @@
+# A sample Gemfile
+source "https://rubygems.org"
+
+gemspec

--- a/dropbox-sdk.gemspec
+++ b/dropbox-sdk.gemspec
@@ -13,6 +13,8 @@ Gem::Specification.new do |s|
 
   s.add_dependency "json"
 
+  s.add_development_dependency "minitest", "~> 4.3.2"
+
   s.homepage = "http://www.dropbox.com/developers/"
   s.summary = "Dropbox REST API Client."
   s.description = <<-EOF


### PR DESCRIPTION
This adds a dependency on the specific necessary minitest version.

It follows the steps outlined at these resources:

http://bundler.io/rubygems.html
http://yehudakatz.com/2010/12/16/clarifying-the-roles-of-the-gemspec-and-gemfile/

To run tests:

bundle install
cd test
DROPBOX_RUBY_SDK_ACCESS_TOKEN=$YOUR_TOKEN bundle exec ruby sdk_test.rb