### PR TITLE
Fix wrong implemention of thumbnail

### DIFF
--- a/lib/dropbox_sdk.rb
+++ b/lib/dropbox_sdk.rb
@@ -1330,9 +1330,8 @@ class DropboxClient
     params = {
       "size" => size
     }
-    headers = nil
     content_server = true
-    @session.do_get path, params, headers, content_server
+    @session.do_get path, params, content_server
   end
   private :thumbnail_impl
 


### PR DESCRIPTION
The method `do-get` need 4 arguments if download from **RubyGems**. However, the **GitHub** version only need 3 arguments. This causes `thumbnail` fail.

```
ArgumentError: wrong number of arguments (4 for 1..3)
	from /Users/yadomi/.rvm/gems/ruby-2.2.0/gems/dropbox-sdk-1.6.4/lib/dropbox_sdk.rb:175:in `do_get'
	from /Users/yadomi/.rvm/gems/ruby-2.2.0/gems/dropbox-sdk-1.6.4/lib/dropbox_sdk.rb:1336:in `thumbnail_impl'
	from /Users/yadomi/.rvm/gems/ruby-2.2.0/gems/dropbox-sdk-1.6.4/lib/dropbox_sdk.rb:1240:in `thumbnail'
	from (irb):8
	from /Users/yadomi/.rvm/rubies/ruby-2.2.0/bin/irb:11:in `<main>'
```

Here's how to fix it.