### PR TITLE
Describe API inconsistencies

### DIFF
--- a/README
+++ b/README
@@ -52,6 +52,34 @@ example, you need to edit the ".rb" file and put your Dropbox API app key and
 secret in the "APP_KEY" and "APP_SECRET" constants.
 
 ----------------------------------
+Inconsistencies
+
+This ruby gem does not exactly follow the API doc published on the Dropbox
+website in some instances. In particular, the following behaviour is
+inconsistent:
+
+* Chunked Upload Commits *
+
+https://www.dropbox.com/developers/core/docs#commit-chunked-upload
+
+The `overwrite` param in this gem is **false** by default, not true.
+E.g. in examples/chunked_upload.rb, consistent behaviour would be achieved by
+passing true as the second argument to `.finish`:
+
+    uploader.finish(dropbox_target_path, true)
+
+
+* Files Put *
+
+https://www.dropbox.com/developers/core/docs#files_put
+
+Similarly, overwrite in this gem is **false** by default.
+E.g. in examples/dropbox_controller.rb:52, consistent behaviour would be
+achieved by passing true as the third argument to `.put_file`:
+
+    client.put_file(params[:file].original_filename, params[:file].read, true)
+
+----------------------------------
 Running the Tests
 
 # gem install bundler
@@ -59,3 +87,4 @@ Running the Tests
 # bundle install
 # cd test
 # DROPBOX_RUBY_SDK_ACCESS_TOKEN=<oauth2-access-token> bundle exec ruby sdk_test.rb
+

--- a/lib/dropbox_sdk.rb
+++ b/lib/dropbox_sdk.rb
@@ -784,6 +784,8 @@ class DropboxClient
   #   You must check the returned metadata to know what this new name is.
   #   This field should only be True if your intent is to potentially
   #   clobber changes to a file that you don't know about.
+  #   NOTE: the official API will default to true. We explicilty default to
+  #   false.
   # * +parent_rev+: The rev field from the 'parent' of this upload. [optional]
   #   If your intent is to update the file at the given path, you should
   #   pass the parent_rev parameter set to the rev value from the most recent
@@ -891,6 +893,8 @@ class DropboxClient
     #   You must check the returned metadata to know what this new name is.
     #   This field should only be True if your intent is to potentially
     #   clobber changes to a file that you don't know about.
+    #   NOTE: the official API will default to true. We explicilty default to
+    #   false.
     # * parent_rev: The rev field from the 'parent' of this upload.
     #   If your intent is to update the file at the given path, you should
     #   pass the parent_rev parameter set to the rev value from the most recent


### PR DESCRIPTION
As discussed in #16, there are two instances where this gem will deviate from the official API. They both relate to the default value of `overwrite` - the official API will default to true, and this gem will default to false.

The Dropbox team want `overwrite` to be false by default for all their SDKs, as it's safer, but will leave the official API defaulting to true for backwards compatibility. Which is fine - I just think it needs to be more explicitly documented in this gem, so users aren't caught unawares :)

I suggest achieving this by including an Inconsistencies section in the README, and a small note on the method documentation for `.finish` and `.put_file`.