### PR TITLE
Add support for longpoll_delta

### DIFF
--- a/dropbox-sdk.gemspec
+++ b/dropbox-sdk.gemspec
@@ -14,6 +14,7 @@ Gem::Specification.new do |s|
   s.add_dependency "json"
 
   s.add_development_dependency "minitest", "~> 4.3.2"
+  s.add_development_dependency "test-unit"
 
   s.homepage = "http://www.dropbox.com/developers/"
   s.summary = "Dropbox REST API Client."

--- a/lib/dropbox_sdk.rb
+++ b/lib/dropbox_sdk.rb
@@ -46,6 +46,7 @@ module Dropbox # :nodoc:
     http.use_ssl = true
     http.verify_mode = OpenSSL::SSL::VERIFY_PEER
     http.ca_file = Dropbox::TRUSTED_CERT_FILE
+    http.read_timeout = 600
 
     if RUBY_VERSION >= '1.9'
       # SSL protocol and ciphersuite settings are supported strating with version 1.9

--- a/lib/dropbox_sdk.rb
+++ b/lib/dropbox_sdk.rb
@@ -10,11 +10,13 @@ require 'pp'
 module Dropbox # :nodoc:
   API_SERVER = "api.dropbox.com"
   API_CONTENT_SERVER = "api-content.dropbox.com"
+  API_NOTIFY_SERVER = "api-notify.dropbox.com"
   WEB_SERVER = "www.dropbox.com"
 
   SERVERS = {
     :api => API_SERVER,
     :content => API_CONTENT_SERVER,
+    :notify => API_NOTIFY_SERVER,
     :web => WEB_SERVER
   }
 

--- a/lib/dropbox_sdk.rb
+++ b/lib/dropbox_sdk.rb
@@ -1335,6 +1335,32 @@ class DropboxClient
     Dropbox::parse_response(response)
   end
 
+  # Calls the long-poll endpoint which waits for changes on an account. In
+  # conjunction with #delta, this call gives you a low-latency way to monitor
+  # an account for file changes.
+  #
+  # The passed in cursor can only be acquired via a call to #delta
+  #
+  # Arguments:
+  # * +cursor+: A delta cursor as returned from a call to #delta
+  # * +timeout+: An optional integer indicating a timeout, in seconds. The
+  #   default value is 30 seconds, which is also the minimum allowed value. The
+  #   maximum is 480 seconds.
+  #
+  # Returns: A hash with one or two fields.
+  # * +changes+: A boolean value indicating whether new changes are available.
+  # * +backoff+: If present, indicates how many seconds your code should wait
+  #   before calling #longpoll_delta again.
+  def longpoll_delta(cursor, timeout=30)
+    params = {
+      'cursor' => cursor,
+      'timeout' => timeout
+    }
+
+    response = @session.do_get "/longpoll_delta", params, :notify
+    Dropbox::parse_response(response)
+  end
+
   # Download a thumbnail (helper method - don't call this directly).
   #
   # Args:

--- a/test/sdk_test.rb
+++ b/test/sdk_test.rb
@@ -301,4 +301,23 @@ class SDKTest < Test::Unit::TestCase
 
     assert_equal(expected, entries)
   end
+
+  def test_longpoll_delta
+    prefix = @test_dir + "delta"
+
+    # Initial cursor has to come from #delta
+    r = @client.delta(nil, prefix)
+    cursor = r['cursor']
+
+    upload(@foo, prefix + "/a.txt")
+    r = @client.longpoll_delta(cursor)
+    assert(r['changes'])
+
+    r = @client.delta(cursor, prefix)
+    cursor = r['cursor']
+
+    # Await timeout
+    r = @client.longpoll_delta(cursor)
+    assert(!r['changes'])
+  end
 end


### PR DESCRIPTION
See commit messages for individual changes.

The test cases are a bit slow for this one, because one of the checks performed is that a timeout response is correctly returned.

This fixes #17 