### PR TITLE
Add support for save_url & save_url_job

### DIFF
--- a/dropbox-sdk.gemspec
+++ b/dropbox-sdk.gemspec
@@ -14,6 +14,7 @@ Gem::Specification.new do |s|
   s.add_dependency "json"
 
   s.add_development_dependency "minitest", "~> 4.3.2"
+  s.add_development_dependency "test-unit", "~> 3.1.2"
 
   s.homepage = "http://www.dropbox.com/developers/"
   s.summary = "Dropbox REST API Client."

--- a/lib/dropbox_sdk.rb
+++ b/lib/dropbox_sdk.rb
@@ -1401,7 +1401,7 @@ class DropboxClient
   def save_url(to_path, url)
     params = { 'url' => url }
 
-    response = @session.do_post "/save_url/auto#{to_path}", params
+    response = @session.do_post "/save_url/auto#{format_path(to_path, true)}", params
     Dropbox::parse_response(response)
   end
 

--- a/lib/dropbox_sdk.rb
+++ b/lib/dropbox_sdk.rb
@@ -1385,6 +1385,41 @@ class DropboxClient
     Dropbox::parse_response(response)
   end
 
+  # Save a file from the specified URL into Dropbox. If the given path already
+  # exists, the file will be renamed to avoid the conflict (e.g. myfile (1).txt).
+  #
+  # Args:
+  # * +to_path+: The path in Dropbox where the file will be saved (e.g. /folder/file.ext).
+  # * +url+: The URL to be fetched.
+  #
+  # Returns:
+  # * A dictionary with a status and job. The status is as defined in the
+  # /save_url_job documentation. The job field gives a job ID that can be used
+  # with the /save_url_job endpoint to check the job's status.
+  # Check https://www.dropbox.com/developers/core/docs#save-url for more info.
+  #     {"status": "PENDING", "job": "PEiuxsfaISEAAAAAAADwzg"}
+  def save_url(to_path, url)
+    params = { 'url' => url }
+
+    response = @session.do_post "/save_url/auto#{to_path}", params
+    Dropbox::parse_response(response)
+  end
+
+  # Check the status of a save URL job.
+  #
+  # Args:
+  # * +job_id+: A job ID returned from /save_url.
+  #
+  # Returns:
+  # *A dictionary with a status field with one of the following values:
+  # PENDING, DOWNLOADING, COMPLETE, FAILED
+  # Check https://www.dropbox.com/developers/core/docs#save-url for more info.
+  #     {"status": "FAILED", "error": "Job timed out"}
+  def save_url_job(job_id)
+    response = @session.do_get "/save_url_job/#{job_id}"
+    Dropbox::parse_response(response)
+  end
+
   #From the oauth spec plus "/".  Slash should not be ecsaped
   RESERVED_CHARACTERS = /[^a-zA-Z0-9\-\.\_\~\/]/  # :nodoc:
 

--- a/test/sdk_test.rb
+++ b/test/sdk_test.rb
@@ -2,6 +2,7 @@ require "test/unit"
 require "../lib/dropbox_sdk"
 require "securerandom"
 require "set"
+require "uri"
 
 class SDKTest < Test::Unit::TestCase
 
@@ -13,7 +14,9 @@ class SDKTest < Test::Unit::TestCase
     @foo = "testfiles/foo.txt"
     @frog = "testfiles/Costa Rican Frog.jpg"
     @song = "testfiles/dropbox_song.mp3"
+    @fluff = "https://www.dropbox.com/s/qmocfrco2t0d28o/Fluffbeast.docx"
 
+    @save_url_statuses = ["PENDING", "COMPLETE", "DOWNLOADING"]
     @test_dir = "/Ruby SDK Tests/" + Time.new.strftime("%Y-%m-%d %H.%M.%S") + "/"
   end
 
@@ -300,5 +303,24 @@ class SDKTest < Test::Unit::TestCase
     end
 
     assert_equal(expected, entries)
+  end
+
+  def test_save_url
+    to_path = URI.encode(@test_dir + "fluff.docx")
+    result = @client.save_url(to_path, @fluff)
+
+    assert_includes(@save_url_statuses, result["status"])
+    assert_includes(result, "job")
+  end
+
+  def test_save_url_job
+    to_path = URI.encode(@test_dir + "fluff.docx")
+    save_url = @client.save_url(to_path, @fluff)
+
+    job_id = save_url["job"]
+    result = @client.save_url_job(job_id)
+
+    assert_includes(@save_url_statuses, result["status"])
+
   end
 end


### PR DESCRIPTION
This adds support for [Programmatically saving a URL to Dropbox](https://blogs.dropbox.com/developers/2015/06/programmatically-saving-a-url-to-dropbox/), the feature released earlier this month.

Support has been added for [/save_url](https://www.dropbox.com/developers/core/docs#save-url) and [/save_url_job](https://www.dropbox.com/developers/core/docs#save-url-job)

In the test for `save_url` I used `https://www.dropbox.com/s/qmocfrco2t0d28o/Fluffbeast.docx` as the remote file because it was listed a few times in Dropbox documentation. It requires a file that will always be available.