### PR TITLE
Protecting against timing attacks

### DIFF
--- a/lib/dropbox_sdk.rb
+++ b/lib/dropbox_sdk.rb
@@ -136,15 +136,21 @@ module Dropbox # :nodoc:
     end
   end
 
-  # A string comparison function that is resistant to timing attacks.  If you're comparing a
-  # string you got from the outside world with a string that is supposed to be a secret, use
-  # this function to check equality.
-  def self.safe_string_equals(a, b)
-    if a.length != b.length
-      false
-    else
-      a.chars.zip(b.chars).map {|ac,bc| ac == bc}.all?
+  # A string comparison function that is resistant to timing attacks. If
+  # you're comparing a string you got from the outside world with a string that
+  # is supposed to be a secret, use this function to check equality.
+  def self.safe_string_equals(trusted, untrusted)
+    same = trusted.size == untrusted.size
+
+    trusted_chars = trusted.chars
+    # This method runs in constant time proportionate to the untrusted input.
+    untrusted.chars.each_with_index do |untrusted_c, idx|
+      unless trusted_chars[idx] == untrusted_c
+        same = false
+      end
     end
+
+    same
   end
 end
 

--- a/test/sdk_test.rb
+++ b/test/sdk_test.rb
@@ -1,5 +1,5 @@
 require "test/unit"
-require "../lib/dropbox_sdk"
+require_relative "../lib/dropbox_sdk"
 require "securerandom"
 require "set"
 


### PR DESCRIPTION
The previous string comparison method didn't operate in constant time.
If the string under test wasn't the same length as the secret the method
instantly returned.

This implementation is constant time with respect to the untrusted
string and executes very quickly (that's why the style is not quite as compact
as one might expect).