### PR TITLE
Easily run tests via Rake

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,21 @@
+
+require 'rake/testtask'
+Rake::TestTask.new do |t|
+  t.libs << "test"
+  t.test_files = FileList['test/test*.rb']
+  t.verbose = true
+end
+
+task :require_token_in_env do
+  unless ENV['DROPBOX_RUBY_SDK_ACCESS_TOKEN']
+    warn "You need to set the DROPBOX_RUBY_SDK_ACCESS_TOKEN env var to run the tests"
+    warn "You can get one by creating an app and generating an access token"
+    warn ""
+    warn "  DROPBOX_RUBY_SDK_ACCESS_TOKEN=some-auth-token rake test"
+    exit 1
+  end
+end
+
+task :default => :test
+# This short-circuits the 'test' task
+task :test => :require_token_in_env

--- a/dropbox-sdk.gemspec
+++ b/dropbox-sdk.gemspec
@@ -14,6 +14,7 @@ Gem::Specification.new do |s|
   s.add_dependency "json"
 
   s.add_development_dependency "minitest", "~> 4.3.2"
+  s.add_development_dependency "rake"
   s.add_development_dependency "test-unit"
 
   s.homepage = "http://www.dropbox.com/developers/"
@@ -24,7 +25,7 @@ Gem::Specification.new do |s|
   EOF
 
   s.files = [
-    "CHANGELOG", "LICENSE", "README",
+    "CHANGELOG", "LICENSE", "README", "Rakefile",
     "examples/cli_example.rb", "examples/dropbox_controller.rb", "examples/web_file_browser.rb",
     "examples/copy_between_accounts.rb", "examples/chunked_upload.rb", "examples/oauth1_upgrade.rb",
     "examples/search_cache.rb",

--- a/test/sdk_test.rb
+++ b/test/sdk_test.rb
@@ -22,9 +22,7 @@ class SDKTest < Test::Unit::TestCase
   end
 
   def teardown
-    unless @test_dir.nil?
-      @client.file_delete(@test_dir) rescue nil
-    end
+    @client.file_delete(@test_dir) rescue nil # already deleted
   end
 
   def hash_has(dict, options={}, *more)

--- a/test/sdk_test.rb
+++ b/test/sdk_test.rb
@@ -1,25 +1,29 @@
 require "test/unit"
-require "../lib/dropbox_sdk"
+require_relative "../lib/dropbox_sdk"
 require "securerandom"
 require "set"
 
 class SDKTest < Test::Unit::TestCase
+
+  def testfile(name)
+    File.expand_path("../testfiles/#{name}", __FILE__)
+  end
 
   # Called before every test method runs. Can be used
   # to set up fixture information.
   def setup
     @client = DropboxClient.new(ENV['DROPBOX_RUBY_SDK_ACCESS_TOKEN'])
 
-    @foo = "testfiles/foo.txt"
-    @frog = "testfiles/Costa Rican Frog.jpg"
-    @song = "testfiles/dropbox_song.mp3"
+    @foo = testfile("foo.txt")
+    @frog = testfile("Costa Rican Frog.jpg")
+    @song = testfile("dropbox_song.mp3")
 
     @test_dir = "/Ruby SDK Tests/" + Time.new.strftime("%Y-%m-%d %H.%M.%S") + "/"
   end
 
   def teardown
     unless @test_dir.nil?
-      @client.file_delete(@test_dir)
+      @client.file_delete(@test_dir) rescue nil
     end
   end
 


### PR DESCRIPTION
The convention in Ruby is to just type `rake` and the project will be
compiled (if necessary) and then run all tests. This change makes that
possible.

Some paths are updated so the current working directory of the developer
running the tests is no longer significant.