### PR TITLE
Add delta_latest_cursor support

### DIFF
--- a/examples/watch_dropbox_deltas.rb
+++ b/examples/watch_dropbox_deltas.rb
@@ -1,0 +1,58 @@
+# An example use of #delta_latest_cursor / #longpoll_delta / #delta calls.
+# "Tails" the delta feed (optionally, for some path_prefix), showing each
+# change entry in near-real-time using the longpoll API.  Each API call, and
+# each result, is shown.  Interrupt (e.g. with CTRL-C) to finish.
+#
+# You'll need to have created an app
+# (https://www.dropbox.com/developers/apps/create), and generated an access
+# token.
+#
+# Example usage:
+#
+# DROPBOX_RUBY_SDK_ACCESS_TOKEN=<oauth2-access-token> ruby watch_dropbox_deltas.rb [<path-prefix>]
+
+require File.expand_path('../../lib/dropbox_sdk', __FILE__)
+
+def get_dropbox_client
+  ENV["DROPBOX_RUBY_SDK_ACCESS_TOKEN"] or raise "You need to set the DROPBOX_RUBY_SDK_ACCESS_TOKEN env var to run this script"
+  dbx = DropboxClient.new(ENV["DROPBOX_RUBY_SDK_ACCESS_TOKEN"])
+end
+
+$stdout.sync = true
+
+dbx = get_dropbox_client
+
+path_prefix = ARGV.first
+
+puts "> latest_cursor #{path_prefix.inspect}"
+lc_r = dbx.delta_latest_cursor(path_prefix)
+puts "< #{lc_r.inspect}"
+cursor = lc_r["cursor"]
+
+while true
+  puts "> longpoll_delta #{cursor.inspect}"
+  lpd_r = dbx.longpoll_delta(cursor)
+  puts "< #{lpd_r.inspect}"
+
+  if lpd_r["changes"]
+
+    puts "> delta #{cursor.inspect}, #{path_prefix.inspect}"
+    d_r = dbx.delta(cursor, path_prefix)
+    puts "< #{d_r.inspect}"
+
+    d_r["entries"].each do |entry|
+      puts " >> #{entry.inspect}"
+    end
+    if d_r["reset"]
+      puts "ALERT!  Local reset requested!"
+    end
+    cursor = d_r["cursor"]
+    next if d_r["has_more"]
+
+  end
+
+  if lpd_r["backoff"]
+    puts "sleeping for #{lpd_r["backoff"]} sec"
+    sleep lpd_r["backoff"]
+  end
+end

--- a/lib/dropbox_sdk.rb
+++ b/lib/dropbox_sdk.rb
@@ -1335,6 +1335,30 @@ class DropboxClient
     Dropbox::parse_response(response)
   end
 
+  # A way to quickly get a cursor for the server's state, for use with #delta.
+  # Unlike #delta, #delta_latest_cursor does not return any entries, so your app
+  # will not know about any existing files or folders in the Dropbox account. For
+  # example, if your app processes future delta entries and sees that a folder was
+  # deleted, your app won't know what files were in that folder. Use this endpoint
+  # if your app only needs to know about new files and modifications and doesn't
+  # need to know about files that already exist in Dropbox.
+
+  # Arguments:
+  # * +path_prefix+: If present, the returned cursor will be encoded with a
+  #   path_prefix for the specified path for use with #delta.
+  #
+  # Returns: A hash with one field.
+  # * +cursor+: A string that encodes the latest server state, as would be
+  #   returned by #delta when "has_more" is false.
+  def delta_latest_cursor(path_prefix=nil)
+    params = {
+      'path_prefix' => path_prefix
+    }
+
+    response = @session.do_post "/delta/latest_cursor", params
+    Dropbox::parse_response(response)
+  end
+
   # Calls the long-poll endpoint which waits for changes on an account. In
   # conjunction with #delta, this call gives you a low-latency way to monitor
   # an account for file changes.

--- a/test/sdk_test.rb
+++ b/test/sdk_test.rb
@@ -310,14 +310,37 @@ class SDKTest < Test::Unit::TestCase
   def test_delta_latest_cursor
     prefix = @test_dir + "delta"
 
+    # First test with no path_prefix
+
     r = @client.delta_latest_cursor
     cursor = r['cursor']
     assert(cursor)
 
+    # Other changes (outside of these tests) might be going on, so we can't
+    # assert anything more about the deltas.
     r = @client.delta(cursor)
+
+    # Going deeper down the tree is OK
+    r = @client.delta(cursor, prefix)
     assert(r['entries'].empty?)
 
-    # Should also test path_prefix
+    # Now test with a path_prefix
+
+    r = @client.delta_latest_cursor(prefix)
+    cursor = r['cursor']
+    assert(cursor)
+
+    r = @client.delta(cursor, prefix)
+    assert(r['entries'].empty?)
+
+    # Going deeper down the tree is OK
+    r = @client.delta(cursor, prefix + "/subdir")
+    assert(r['entries'].empty?)
+
+    # Going up (outside of the scope of the cursor) is not OK
+    assert_raise DropboxError do
+      @client.delta(cursor, nil)
+    end
   end
 
   def test_longpoll_delta

--- a/test/sdk_test.rb
+++ b/test/sdk_test.rb
@@ -307,6 +307,19 @@ class SDKTest < Test::Unit::TestCase
     assert_equal(expected, entries)
   end
 
+  def test_delta_latest_cursor
+    prefix = @test_dir + "delta"
+
+    r = @client.delta_latest_cursor
+    cursor = r['cursor']
+    assert(cursor)
+
+    r = @client.delta(cursor)
+    assert(r['entries'].empty?)
+
+    # Should also test path_prefix
+  end
+
   def test_longpoll_delta
     prefix = @test_dir + "delta"
 


### PR DESCRIPTION
I've deliberately omitted include_media_info for now, since it's also missing from #delta 
