### PR TITLE
Fix duplicate dependency on test-unit

### DIFF
--- a/dropbox-sdk.gemspec
+++ b/dropbox-sdk.gemspec
@@ -15,7 +15,6 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency "minitest", "~> 4.3.2"
   s.add_development_dependency "rake"
-  s.add_development_dependency "test-unit"
   s.add_development_dependency "test-unit", "~> 3.1.2"
 
   s.homepage = "http://www.dropbox.com/developers/"


### PR DESCRIPTION
The test-unit dependency was added twice due to a bad merge in 235126554d301b8a679ec7e63596674406028f62.
Without this fix bundler fails with a "duplicate dependency on test-unit" error.