### PR TITLE
added large warning re: API v1 usage not being acceptable

### DIFF
--- a/README
+++ b/README
@@ -1,3 +1,10 @@
+=====================================================================================================
+WARNING: THIS GEM USES THE NOW DEPRECATED V1 API; APPS USING IT WILL NOT BE ACCEPTED INTO PRODUCTION.
+=====================================================================================================
+More info: https://blogs.dropbox.com/developers/2016/06/api-v1-deprecated/
+=====================================================================================================
+
+
 Dropbox Core SDK for Ruby
 
 A Ruby library that for Dropbox's HTTP-based Core API.


### PR DESCRIPTION
Developers should not make mistake of using this and then having their apps denied from production status.